### PR TITLE
test depending on very user-specific paths made pass anywhere (= 1 failing test fixed)

### DIFF
--- a/tests/data/00001.gabc
+++ b/tests/data/00001.gabc
@@ -1,0 +1,17 @@
+name:Laudem Domini;
+office-part:al;
+mode:1;
+transcriber:Andrew Hinkley;
+gabc-copyright:CC0-1.0 <http://creativecommons.org/publicdomain/zero/1.0/>;
+_gregobase_corpus_version:0.4;
+_gregobase_id:1;
+_gregobase_url:https://gregobase.selapa.net/chant.php?id=1;
+_gregobase_sources:2,3;
+_gregobase_source_0_id:2;
+_gregobase_source_0_title:Graduale Romanum;
+_gregobase_source_0_year:1961;
+_gregobase_source_1_id:3;
+_gregobase_source_1_title:The Liber Usualis;
+_gregobase_source_1_year:1961;
+%%
+(c4) AL(dc~)le(c/e'gF'EC'd)lú(dc/fg!hvGF'g)ia.(g.) *(;) <i>ij.</i>(hghvGFg_fgvFDffdev.dec.,e/ggh'GFgvFEffdevDCd!ewfd.) <sp>V/</sp>.(::) Lau(h)dem(ghG'E) Dó(fe)mi(fg)ni(gvF'EC'dw!evDCd.) (;) lo(d)qué(d/ffe/ggh)tur(fvED) os(cd) me(d!ewfd)um,(d.) (:) et(de) be(gh)ne(gh)dí(h!iwj/ki'jvH'G/h!iwjh)cat(h.) (,) o(h_ghvGF)mnis(fvED) ca(c.d!ewfd)ro(d.) (;) no(de)men(gh) san(ghgh)ctum(h.) *(,) e(h!iwj/ki'jvH'G/h!iwjh)jus.(h,hghvGFg_fgvFDffdev.dec.,e/ggh'GFgvFEffd/evDCd!ewfd.) (::)

--- a/tests/test_gabc_examples.py
+++ b/tests/test_gabc_examples.py
@@ -40,8 +40,7 @@ class TestParseExamples(unittest.TestCase):
     #         self.runTest(filename)
 
     def test_GBCParsing(self):
-        GABC_FN = '/Users/Bas/repos/projects/GregoBaseCorpus/dist/gregobasecorpus-v0.3/gregobasecorpus-v0.3/gabc/{idx:0>5}.gabc'
-        filename = GABC_FN.format(idx=1)
+        filename = 'tests/data/00001.gabc'
         parser = ParserGABC()
         parse = parser.parseFile(filename)
         self.assertFalse(parse.error)


### PR DESCRIPTION
Relative path in the test code expects cwd to be the repository root directory.

I considered rewriting the test so as to accept path to the GregoBaseCorpus e.g. in an environment variable or in some other kind of configuration and orchestrating retrieval of the corpus on the CI, but since only a single file of the whole corpus is really used, it's much more efficient and future-proof to simply copy it in the source tree.