### PR TITLE
tests: make sure required directory exists (= 2 failing tests fixed)

### DIFF
--- a/tests/test_cantus_examples.py
+++ b/tests/test_cantus_examples.py
@@ -11,6 +11,16 @@ from chant21.cantus import addCantusMetadataToChant
 from chant21.cantus import convertCantusData
 
 class TestCantusExamplesConversion(unittest.TestCase):
+    _tmp_dir = 'tmp/cantus-html'
+
+    def setUp(self):
+        os.makedirs(self._tmp_dir, exist_ok=True)
+
+    def tearDown(self):
+        dir = self._tmp_dir
+        for i in os.listdir(dir):
+            os.remove(os.path.join(dir, i))
+
     def test_parse_volpiano_examples(self):
         """Test whether the volpiano of all Cantus examples can be parsed"""
         examples = pd.read_csv('chant21/examples/cantus-volpiano-examples.csv', index_col=0)


### PR DESCRIPTION
Make the tests more robust, not relying on existence of a manually created directory.